### PR TITLE
compile nginx with mod_zip instead of conda pre-compiled version

### DIFF
--- a/Images/qiita/Dockerfile
+++ b/Images/qiita/Dockerfile
@@ -1,17 +1,23 @@
 FROM ubuntu:24.04
 
 ARG MINIFORGE_VERSION=24.1.2-0
+ARG MODZIP_VERSION=1.3.0
+ARG NGINX_VERSION=1.26.0
 
 ENV CONDA_DIR=/opt/conda
 ENV PATH=${CONDA_DIR}/bin:${PATH}
 
 RUN apt-get -y update
+# install following packages for nginx compilation: libpcre2-dev, libxslt-dev and libgd-dev
 RUN apt-get -y --fix-missing install \
 	git \
 	wget \
 	libpq-dev \
 	python3-dev \
-	gcc
+	gcc \
+	libpcre2-dev \
+	libxslt-dev \
+	libgd-dev
 RUN apt-get -y install build-essential
 # install miniforge3 for "conda"
 # see https://github.com/conda-forge/miniforge-images/blob/master/ubuntu/Dockerfile
@@ -22,7 +28,7 @@ RUN wget https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_
 	conda init
 
 # create conda env for qiita with all necessary dependencies (conda and pip)
-RUN conda create --quiet --yes -n qiita python=3.9 pip libgfortran numpy nginx cython anaconda::redis
+RUN conda create --quiet --yes -n qiita python=3.9 pip libgfortran numpy cython anaconda::redis
 
 # Make RUN commands use the new environment:
 # append --format docker to the build command, see https://github.com/containers/podman/issues/8477
@@ -36,6 +42,51 @@ RUN pip install \
 	Click \
 	coverage \
 	psycopg2-binary
+	
+# manually compile nginx to enable mod_zip
+RUN wget https://github.com/evanmiller/mod_zip/archive/refs/tags/${MODZIP_VERSION}.tar.gz -O /usr/local/src/mod_zip-${MODZIP_VERSION}.tar.gz
+RUN cd /usr/local/src/ && tar xzvf mod_zip-${MODZIP_VERSION}.tar.gz
+RUN wget https://github.com/nginx/nginx/archive/refs/tags/release-${NGINX_VERSION}.tar.gz -O /usr/local/src/nginx-${NGINX_VERSION}.tar.gz
+RUN cd /usr/local/src/ && tar xzvf nginx-${NGINX_VERSION}.tar.gz
+# fix include for the iconv header
+RUN sed "s|^#include <iconv.h>|#include \"/usr/include/iconv.h\"|" -i /usr/local/src/mod_zip-${MODZIP_VERSION}/ngx_http_zip_file.c
+# ensure runtime library paths are correct and openssl headers can be found at compile time
+RUN cd /usr/local/src/nginx-release-${NGINX_VERSION} && ./auto/configure \
+	--http-log-path=var/log/nginx/access.log \
+	--error-log-path=var/log/nginx/error.log \
+	--pid-path=var/run/nginx/nginx.pid \
+	--lock-path=var/run/nginx/nginx.lock \
+	--http-client-body-temp-path=var/tmp/nginx/client \
+	--http-proxy-temp-path=var/tmp/nginx/proxy \
+	--http-fastcgi-temp-path=var/tmp/nginx/fastcgi \
+	--http-scgi-temp-path=var/tmp/nginx/scgi \
+	--http-uwsgi-temp-path=var/tmp/nginx/uwsgi \
+	--sbin-path=sbin/nginx \
+	--conf-path=etc/nginx/nginx.conf \
+	--modules-path=lib/nginx/modules \
+	--with-threads \
+	--with-http_ssl_module \
+	--with-http_v2_module \
+	--with-http_realip_module \
+	--with-http_addition_module \
+	--with-http_sub_module \
+	--with-http_gunzip_module \
+	--with-http_gzip_static_module \
+	--with-http_auth_request_module \
+	--with-http_secure_link_module \
+	--with-http_stub_status_module \
+	--with-http_xslt_module=dynamic \
+	--with-stream=dynamic \
+	--with-http_image_filter_module=dynamic \
+	--with-pcre \
+	--with-pcre-jit \
+	--with-cc-opt=" -I $CONDA_DIR/envs/qiita/include/openssl " \
+	--with-ld-opt="" \
+	--prefix=/usr/local \
+	--add-module=/usr/local/src/mod_zip-${MODZIP_VERSION} \
+	--with-ld-opt=" -Wl,-rpath,$CONDA_DIR/envs/qiita/lib "
+RUN cd /usr/local/src/nginx-release-${NGINX_VERSION} && make
+RUN cd /usr/local/src/nginx-release-${NGINX_VERSION} && make install
 
 #cClone the Qiita Repo
 # RUN git clone -b master https://github.com/qiita-spots/qiita.git


### PR DESCRIPTION
Hi @Anna-Rehm 
this PR should result in a compiled nginx version with mod_zip activated in `/usr/local/bin` (or was it `/usr/local/sbin`?) which is a dir of the $PATH env variable, i.e. should be a direct replacement of the previously conda installed nginx package.

P.S. my flight is delayed by 4h :-/