### PR TITLE
WIP: Non def ports

### DIFF
--- a/Images/qiita/config_qiita_oidc.cfg
+++ b/Images/qiita/config_qiita_oidc.cfg
@@ -121,7 +121,7 @@ DATABASE = qiita_test
 HOST = localhost
 
 # The port to connect to the database
-PORT = 5432
+PORT = 5433
 
 # The password to use to connect to the database
 PASSWORD = postgres

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,8 @@ services:
       - './environments/qiita-db-init.sh:/docker-entrypoint-initdb.d/qiita-db-init.sh'
       - 'postgres-data:/var/lib/postgresql/data'
     ports:
-      - "5432:5432"
+      - "5433:5433"
+    command: -p 5433
 
   qiita:
       image: qiita:latest 


### PR DESCRIPTION
stupid me ran into issues with postgres, as I forgot that I already ran a native postgress server in my system and was confused that the containerized postgres server raised issues with port already in use. This let the containerized qiita talk to the wrong server.
To saveguard other we might want to change `network_mode` in the future, but for debugging it might be easier to use non default ports for now