### PR TITLE
hide workflows to NOT filter commands for artifact processing

### DIFF
--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -75,4 +75,6 @@ RUN rm -rf /qiita/qiita_core/support_files
 # hide default configurations from github sources
 RUN rm -f /qiita/qiita_pet/nginx_example.conf /qiita/qiita_pet/supervisor_example.conf /qiita/qiita_pet/support_files/config_portal.cfg
 
+COPY drop_workflows.py /drop_workflows.py
+
 # CMD ["conda", "run", "-n", "qiita"]

--- a/Images/qiita/start_qiita-initDB.sh
+++ b/Images/qiita/start_qiita-initDB.sh
@@ -8,3 +8,9 @@ ENV_NAME=qiita
 source $CONDA_DIR/etc/profile.d/conda.sh; conda activate $CONDA_DIR/envs/$ENV_NAME; cd /qiita; qiita-env make --no-load-ontologies 2> .env-make.err || true
 # To avoid confusing the user, STDERR is written into a file and only reported if it does not contain the text that we expect to see if it just reports the existing DB
 grep 'already present on the system. You can drop it by running' .env-make.err > /dev/null || cat .env-make.err
+
+
+# currently, commands with which you can process artifacts are limited to those that are present in available "recommended workflows".
+# As they are not properly set up in the test database, we e.g. cannot run "deblur" on demux or trimmed existing artifacts (it's different in workflows in construction)
+# As long as we don't have a nice mechanism to carry over recommended workflow, we better remove them altogether
+source $CONDA_DIR/etc/profile.d/conda.sh; conda activate $CONDA_DIR/envs/$ENV_NAME; python /drop_workflows.py

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ plugin: Images/qtp-biom/trigger.py Certificates/
 	chmod a+rw ./logs/nginx_access.log ./logs/nginx_error.log
 	touch .built_image_nginx
 
-.built_image_qiita: Images/qiita/qiita.dockerfile Images/qiita/config_qiita_oidc.cfg Images/qiita/start_qiita.sh Images/qiita/start_qiita-initDB.sh Images/qiita/supervisor_foreground.conf Images/qiita/start_plugin.py Images/qiita/config_portal.cfg
+.built_image_qiita: Images/qiita/qiita.dockerfile Images/qiita/config_qiita_oidc.cfg Images/qiita/start_qiita.sh Images/qiita/start_qiita-initDB.sh Images/qiita/supervisor_foreground.conf Images/qiita/start_plugin.py Images/qiita/config_portal.cfg Images/qiita/drop_workflows.py
 	test -d src/qiita || git clone -b auth_oidc https://github.com/jlab/qiita.git src/qiita
 	# remove configuration and certificate files from upstream qiita repo
 	rm -rf src/qiita/qiita_core/support_files


### PR DESCRIPTION
Currently, commands with which you can process artifacts are limited to those that are present in available "recommended workflows".
As they are not properly set up in the test database, we e.g. cannot run "deblur" on demux or trimmed existing artifacts (it's different in workflows in construction)
As long as we don't have a nice mechanism to carry over recommended workflow, we better remove them altogether