### PR TITLE
Sync qiime2

### DIFF
--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -80,4 +80,7 @@ COPY drop_workflows.py /drop_workflows.py
 # install aspera client for ENA submission
 RUN conda install hcc::aspera-cli
 
+# something is wired with permissions of the git repo?!
+RUN git config --global --add safe.directory /qiita
+
 # CMD ["conda", "run", "-n", "qiita"]

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -28,11 +28,11 @@ RUN pip install -U pip
 RUN conda install tornado
 COPY trigger.py /trigger.py
 
-# Download qiime2 yaml
-RUN wget -q https://data.qiime2.org/distro/core/qiime2-2019.10-py36-linux-conda.yml
+# Download qiime2 yaml (make sure to use a qiime2 version that is able to visualize qiime artifacts of the correct version)
+RUN wget --quiet https://data.qiime2.org/distro/core/qiime2-2023.5-py38-linux-conda.yml
 
 # Create conda env
-RUN conda env create --name qtp-visualization -y --file qiime2-2019.10-py36-linux-conda.yml
+RUN conda env create --name qtp-visualization -y --file qiime2-2023.5-py38-linux-conda.yml
 # Make RUN commands use the new environment:
 # append --format docker to the build command, see https://github.com/containers/podman/issues/8477
 SHELL ["conda", "run", "-p", "/opt/conda/envs/qtp-visualization", "/bin/bash", "-c"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -259,8 +259,8 @@ services:
       - ./Images/qiita/config_qiita_oidc.cfg:/qiita_configurations/qiita_server.cfg:r  # TODO: do we really want to expose server settings to the plugin?
     environment:
       # TODO: is there a more elegant way to obtain this path?
-      - REQUESTS_CA_BUNDLE=/opt/conda/envs/qtp-visualization/lib/python3.6/site-packages/certifi/cacert.pem
-      - SSL_CERT_FILE=/opt/conda/envs/qtp-visualization/lib/python3.6/site-packages/certifi/cacert.pem
+      - REQUESTS_CA_BUNDLE=/opt/conda/envs/qtp-visualization/lib/python3.8/site-packages/certifi/cacert.pem
+      - SSL_CERT_FILE=/opt/conda/envs/qtp-visualization/lib/python3.8/site-packages/certifi/cacert.pem
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
       - QIITA_CONFIG_FP=/qiita_configurations/qiita_server.cfg
     networks:


### PR DESCRIPTION
The qiime2 version in the qtp-visualization plugin was too old to "view" qzv / qza produced by plugins with more recent qiime2 versions installed :-/

In addition, qiita errored with a complained about dubious git file permissions. Most likely due to sudo make ...