### PR TITLE
refactor names of qiita certificate

### DIFF
--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -22,8 +22,8 @@ jobs:
         # second copy of "qiita_server_certificates" is necessary to match path for docker build, first copy for mounting into container
         run: |
           sed -i "s/^SECURE_QIITA_DB = True/SECURE_QIITA_DB = False/" ./Configuration/makefile
-          make ./references/qiita_server_certificates propagate_configuration
-          cp -r ./references/qiita_server_certificates ./qiita_server_certificates
+          make ./references/Certificates/tinqiita propagate_configuration
+          cp -r ./references/Certificates/tinqiita ./qiita_server_certificates
 
       - name: Store certifactes for follow up jobs
         uses: actions/upload-artifact@v4
@@ -31,7 +31,7 @@ jobs:
           name: certificates
           path: |
             ./qiita_server_certificates
-            ./references/qiita_server_certificates
+            ./references/Certificates/tinqiita
             ./Configuration
 
   build_main:

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -19,18 +19,18 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create certificate
-        # second copy of "qiita_server_certificates" is necessary to match path for docker build, first copy for mounting into container
+        # second copy of "./Certificates" is necessary to match path for docker build, first copy for mounting into container
         run: |
           sed -i "s/^SECURE_QIITA_DB = True/SECURE_QIITA_DB = False/" ./Configuration/makefile
           make ./references/Certificates/tinqiita propagate_configuration
-          cp -r ./references/Certificates/tinqiita ./qiita_server_certificates
+          cp -r ./references/Certificates ./Certificates
 
       - name: Store certifactes for follow up jobs
         uses: actions/upload-artifact@v4
         with:
           name: certificates
           path: |
-            ./qiita_server_certificates
+            ./Certificates
             ./references/Certificates/tinqiita
             ./Configuration
 

--- a/Configuration/makefile
+++ b/Configuration/makefile
@@ -36,26 +36,25 @@ SECURE_QIITA_DB = False
 #    registered). The plugin_collector service iterates over plugins and
 #    transfers these files to main, such that main can add the according values
 #    into the database.
-CERTNAME=tinqiita
 OPENSSL=/bin/openssl
-$(DIR_REFERENCES)/qiita_server_certificates: Configuration/$(CERTNAME)_csr.conf Configuration/$(CERTNAME)_cert.conf
+$(DIR_REFERENCES)/Certificates/%: Configuration/%_csr.conf Configuration/%_cert.conf
 	# === create own certificates ===
 	mkdir -p $@
 	# Generate a new root CA private key and certificate
-	cd $@ && $(OPENSSL) req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=tinqiita-nginx-1/C=DE/L=Giessen" -keyout $(CERTNAME)_rootca.key -out $(CERTNAME)_rootca.crt
+	cd $@ && $(OPENSSL) req -x509 -sha256 -days 356 -nodes -newkey rsa:2048 -subj "/CN=tinqiita-nginx-1/C=DE/L=Giessen" -keyout $*_rootca.key -out $*_rootca.crt
 	# Generate a new server private key
-	cd $@ && $(OPENSSL) genrsa -out $(CERTNAME)_server.key 2048
+	cd $@ && $(OPENSSL) genrsa -out $*_server.key 2048
 	# Copy the following to a new file named csr.conf and modify to suit your needs
 	# Copy the following to a new file named cert.conf and modify to suit your needs
 	# Nils: alt_names is the important aspect. Make entries for all valid hostnames with which services shall be addressed
 	for f in `echo "$^"`; do cat $$f > $@/`basename $$f`; done
 	#cp $^ $@/
 	# Generate a certificate signing request
-	cd $@ && $(OPENSSL) req -new -key $(CERTNAME)_server.key -out $(CERTNAME)_server.csr -config $(CERTNAME)_csr.conf
+	cd $@ && $(OPENSSL) req -new -key $*_server.key -out $*_server.csr -config $*_csr.conf
 	# Generate a new signed server.crt to use with your server.key
-	cd $@ && $(OPENSSL) x509 -req -in $(CERTNAME)_server.csr -CA $(CERTNAME)_rootca.crt -CAkey $(CERTNAME)_rootca.key -CAcreateserial -out $(CERTNAME)_server.crt -days 365 -sha256 -extfile $(CERTNAME)_cert.conf
+	cd $@ && $(OPENSSL) x509 -req -in $*_server.csr -CA $*_rootca.crt -CAkey $*_rootca.key -CAcreateserial -out $*_server.crt -days 365 -sha256 -extfile $*_cert.conf
 	# concat rootca and server certificates into one file
-	cd $@ && cat $(CERTNAME)_rootca.crt $(CERTNAME)_server.crt > qiita_server_certificates.pem
+	cd $@ && cat $*_rootca.crt $*_server.crt > $*_server_certificates.pem
 	# === end: create own certificates ===
 
 RANDOMPWD = $(shell python -c "from base64 import b64encode; from uuid import uuid4; phrase=b64encode(uuid4().bytes + uuid4().bytes); print(phrase.decode())")

--- a/Images/makefile
+++ b/Images/makefile
@@ -8,7 +8,7 @@ tmpdir = $(TMPDIR)
 endif
 
 # a general target, executed for each plugin
-plugin: Images/trigger.py Images/start_plugin.sh $(DIR_REFERENCES)/qiita_server_certificates Images/test_plugin.sh
+plugin: Images/trigger.py Images/start_plugin.sh $(DIR_REFERENCES)/Certificates/tinqiita Images/test_plugin.sh
 	cp -r $^ $(tmpdir)/
 
 .built_image_qtp-biom: Images/qtp-biom/qtp-biom.dockerfile src/qiita-files/ src/qtp-biom/ Images/qtp-biom/requirements.txt

--- a/Images/makefile
+++ b/Images/makefile
@@ -8,7 +8,7 @@ tmpdir = $(TMPDIR)
 endif
 
 # a general target, executed for each plugin
-plugin: Images/trigger.py Images/start_plugin.sh $(DIR_REFERENCES)/Certificates/tinqiita Images/test_plugin.sh
+plugin: Images/trigger.py Images/start_plugin.sh $(DIR_REFERENCES)/Certificates Images/test_plugin.sh
 	cp -r $^ $(tmpdir)/
 
 .built_image_qtp-biom: Images/qtp-biom/qtp-biom.dockerfile src/qiita-files/ src/qtp-biom/ Images/qtp-biom/requirements.txt

--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -53,10 +53,7 @@ RUN git clone -b auth_oidc https://github.com/jlab/qiita.git \
 	&& cd qiita \
 	&& git config pull.rebase false \
 	&& git config --global user.email "jlab@uni-giessen.de" \
-	&& git config --global user.name "Stefan" && \
-	git pull origin  tornado_FetchFileFromCentralHandler && \
-	git remote add antgonza https://github.com/antgonza/qiita.git && \
-	git pull antgonza autoremove-files-created-during-testing
+	&& git config --global user.name "Stefan"
 
 # should tests re-populate the DB, ensure private plugin, qtp-biom and qp-target-gene use the correct conda env
 RUN sed -i "s|'source /home/runner/.profile; conda activate qiita'|'source /opt/conda/etc/profile.d/conda.sh; conda activate /opt/conda/envs/qiita'|" /qiita/qiita_db/support_files/populate_test_db.sql

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -129,7 +129,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -129,7 +129,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -129,9 +129,9 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -115,7 +115,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -115,9 +115,9 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 RUN mkdir -p ${QIITA_PLUGINS_DIR}/

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -115,7 +115,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -135,7 +135,7 @@ RUN pip3 install tornado
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -135,7 +135,7 @@ RUN pip3 install tornado
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -135,9 +135,9 @@ RUN pip3 install tornado
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -139,9 +139,9 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -139,7 +139,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -139,7 +139,7 @@ WORKDIR /
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -172,7 +172,7 @@ RUN cd /usr/local/lib/python3.8/site-packages/q2_diversity && tar xzvf q2_divers
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -172,7 +172,7 @@ RUN cd /usr/local/lib/python3.8/site-packages/q2_diversity && tar xzvf q2_divers
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -172,9 +172,9 @@ RUN cd /usr/local/lib/python3.8/site-packages/q2_diversity && tar xzvf q2_divers
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -99,9 +99,9 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -99,7 +99,7 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -99,7 +99,7 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -110,7 +110,7 @@ RUN ln -s /usr/local/bin/quast.py /usr/local/bin/quast
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -110,9 +110,9 @@ RUN ln -s /usr/local/bin/quast.py /usr/local/bin/quast
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 # setup qiita plugin
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -110,7 +110,7 @@ RUN ln -s /usr/local/bin/quast.py /usr/local/bin/quast
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -121,7 +121,7 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -121,7 +121,7 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
+COPY Certificates/tinqiita/*_server* ${QIITA_CERT_DIR}/
 ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -121,9 +121,9 @@ RUN pip install --no-cache-dir /wheels/* \
 
 # Handling of certificates, such that plugin can verify qiita main
 RUN mkdir -p ${QIITA_CERT_DIR}/
-COPY qiita_server_certificates/*_server* ${QIITA_CERT_DIR}/
-ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
-ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/qiita_server_certificates.pem
+COPY tinqiita/*_server* ${QIITA_CERT_DIR}/
+ENV REQUESTS_CA_BUNDLE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
+ENV SSL_CERT_FILE=${QIITA_CERT_DIR}/tinqiita_server_certificates.pem
 
 ENV QIITA_PLUGINS_DIR=${QIITA_PLUGINS_DIR}
 # qiime2 expects to have a CONDA_PREFIX set, see https://github.com/qiime2/qiime2/blob/812fd09cf80b4ed76c1f39827ae2dba729448436/qiime2/sdk/parallel_config.py#L30

--- a/compose_github.yaml
+++ b/compose_github.yaml
@@ -60,7 +60,7 @@ services:
         - ./Configuration/config_qiita_oidc.cfg:/qiita_configurations/qiita_server.cfg:ro
         - ./Configuration/config_portal.cfg:/qiita_configurations/config_portal.cfg:ro
         - server-plugin-configs:/qiita_plugins
-        - ./references/qiita_server_certificates:/qiita_certificates
+        - ./references/Certificates/tinqiita:/qiita_certificates
         - test_tmp_dir:/tmp
       networks:
         - qiita-net
@@ -87,7 +87,7 @@ services:
         - ./Configuration/config_qiita_oidc.cfg:/qiita_configurations/qiita_server.cfg:ro
         - ./Configuration/config_portal.cfg:/qiita_configurations/config_portal.cfg:ro
         - server-plugin-configs:/qiita_plugins
-        - ./references/qiita_server_certificates:/qiita_certificates
+        - ./references/Certificates/tinqiita:/qiita_certificates
         - test_tmp_dir:/tmp
       networks:
         - qiita-net
@@ -124,7 +124,7 @@ services:
       - qiita-data:/qiita_data
       - qiita-logs:/logs
       - ./Configuration/nginx_qiita.conf:/qiita_configuration/nginx_qiita.conf
-      - ./references/qiita_server_certificates:/qiita_certificates
+      - ./references/Certificates/tinqiita:/qiita_certificates
     networks:
       - qiita-net
     # healthcheck:
@@ -142,7 +142,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
@@ -154,7 +154,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
@@ -172,7 +172,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
       - ./references/qp-target-gene:/databases/gg/13_8/rep_set
     environment:
@@ -185,7 +185,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
@@ -197,7 +197,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
@@ -209,7 +209,7 @@ services:
     restart: "no"
     volumes:
       # - qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - ./references/qp-deblur:/opt/conda/envs/qp-deblur/share/fragment-insertion/ref
       - test_tmp_dir:/tmp
     environment:
@@ -222,7 +222,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG
@@ -235,7 +235,7 @@ services:
     restart: "no"
     volumes:
       #- qiita-data:/qiita_data
-      - ./references/qiita_server_certificates:/qiita_server_certificates
+      - ./references/Certificates/tinqiita:/qiita_server_certificates
       - test_tmp_dir:/tmp
     environment:
       - QIITA_CLIENT_DEBUG_LEVEL=DEBUG


### PR DESCRIPTION
Turns out not only the plugins need to verify qiita pet, but also qiita wants to verify the certificate of a local keycloak service. Keycloak enforces using certificates once it is run in production mode.
I here rename the certificate, basically to reuse the make target that creates certificates for qiita and keycloak.