### PR TITLE
Test proper ca cert

### DIFF
--- a/Configuration/tinqiita_csr.conf
+++ b/Configuration/tinqiita_csr.conf
@@ -1,9 +1,9 @@
 [ req ]
-default_bits = 2048
+default_bits = 4096
 prompt = no
 default_md = sha256
-req_extensions = req_ext
 distinguished_name = dn
+x509_extensions = v3_ca
 
 [ dn ]
 C = DE
@@ -11,16 +11,12 @@ ST = Hesse
 L = Giessen
 O = JLU
 OU = tinqiita
-CN = localhost
+CN = tinqiita Root CA
 
 [ req_ext ]
 subjectAltName = @alt_names
 
-[ alt_names ]
-IP.1 = 127.0.0.1
-DNS.1 = localhost
-DNS.2 = tinqiita-qiita-1
-DNS.3 = tinqiita-qiita-worker-1
-DNS.4 = tinqiita-qiita-worker-2
-DNS.5 = tinqiita-qiita-worker-3
-DNS.6 = tinqiita-nginx-1
+[ v3_ca ]
+basicConstraints = critical, CA:TRUE, pathlen:0
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash


### PR DESCRIPTION
When I realized that CA cert configuration was wrong for the new keycloak certificate, I here test if similar changes to the "older" tinqiita certificate (enable plugins to verify qiita main) breaks anything