### PR TITLE
switch to qiita-spots master/main for plugins

### DIFF
--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create certificate
         # second copy of "./Certificates" is necessary to match path for docker build, first copy for mounting into container
@@ -26,7 +26,7 @@ jobs:
           cp -r ./references/Certificates ./Certificates
 
       - name: Store certifactes for follow up jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: certificates
           path: |
@@ -45,10 +45,10 @@ jobs:
       GIT_QIITA_BRANCH: "auth_oidc"
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Read image version from dockerfile
         id: vars
@@ -66,7 +66,7 @@ jobs:
           path: ./          
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create partially fake reference databases
         run: |
@@ -104,7 +104,7 @@ jobs:
           for f in `echo "references/qp-target-gene/97_otus.fasta references/qp-target-gene/97_otus.tree references/qp-target-gene/97_otu_taxonomy.txt"`; do echo "fake" > $f; done
 
       - name: Store fake references for follow up jobs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fake_references
           path: |
@@ -127,10 +127,10 @@ jobs:
       GIT_QIITACLIENT_BRANCH: "master"
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Read image version from dockerfile
         id: vars
@@ -152,7 +152,7 @@ jobs:
           path: ./references
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Show Debug Logfiles
         #if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debug logs
           path: ./debug
@@ -240,10 +240,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Read image version from dockerfile
         id: vars
@@ -264,7 +264,7 @@ jobs:
           path: ./
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -324,17 +324,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tinqiita repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to computational.bio registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: harbor.computational.bio.uni-giessen.de
           username: ${{ vars.HARBOR_CB_USERNAME }}

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -76,10 +76,8 @@ jobs:
           push: true
           file: Images/${{ matrix.container }}/${{ matrix.container }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:testcandidate
-        #  cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
-          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}-main
-        #  cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
-          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }}-main,mode=max
+          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
+          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
           platforms: linux/amd64
   make_references:
     needs: build_main
@@ -150,8 +148,8 @@ jobs:
           context: .
           file: Images/${{ matrix.plugin }}/${{ matrix.plugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate
-          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
-          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
+          cache-from: type=gha,scope=tinqiita-plugin-${{ matrix.plugin }}-${{ github.ref_name }}
+          cache-to: type=gha,scope=tinqiita-plugin-${{ matrix.plugin }}-${{ github.ref_name }},mode=max
           platforms: linux/amd64
 
       - name: adapt compose file to select specific plugin
@@ -164,8 +162,10 @@ jobs:
           compose-file: "compose.yaml"
           services: |
             nginx
-      - name: Check which qiita image is actually running
-        run: docker inspect ghcr.io/${{ github.repository }}/qiita:testcandidate --format '{{.Id}}'
+      - name: Check which qiita and plugin image is actually running
+        run: |
+          docker inspect ghcr.io/${{ github.repository }}/qiita:testcandidate --format '{{.Id}}'
+          docker inspect ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate --format '{{.Id}}'
       - name: Show docker compose logs
         if: failure()
         run: |
@@ -241,8 +241,8 @@ jobs:
           context: .
           file: Images/${{ matrix.multiplugin }}/${{ matrix.multiplugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate
-          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
-          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
+          cache-from: type=gha,scope=tinqiita-plugin-${{ matrix.multiplugin }}-${{ github.ref_name }}
+          cache-to: type=gha,scope=tinqiita-plugin-${{ matrix.multiplugin }}-${{ github.ref_name }},mode=max
           platforms: linux/amd64
 
       - name: Prune build cache after build (saving disc space)

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -60,7 +60,7 @@ jobs:
           cp Images/plugin_collector/collect_configs.py Images/plugin_collector/fix_test_db.py Configuration/tinqiita_cert.conf Configuration/tinqiita_csr.conf Images/plugin_collector/start_plugin_collector.sh .
 
       - name: Download certificates from job build_main
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: certificates
           path: ./          
@@ -77,7 +77,7 @@ jobs:
           echo "CACHEBURST_QIITA=$(git ls-remote https://github.com/$GIT_QIITA_FORK/qiita.git refs/heads/$GIT_QIITA_BRANCH | cut -f1)" >> $GITHUB_ENV
 
       - name: Build main qiita images and push to github's own registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -141,12 +141,12 @@ jobs:
           mkdir -p ./debug
 
       - name: Download certificates from job build_main
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: certificates
           path: ./
       - name: Download fake references
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: fake_references
           path: ./references
@@ -166,20 +166,20 @@ jobs:
           echo "CACHEBURST_QIITACLIENT=$(git ls-remote https://github.com/$GIT_QIITACLIENT_FORK/qiita_client.git refs/heads/$GIT_QIITACLIENT_BRANCH | cut -f1)" >> $GITHUB_ENV
 
       - name: Build plugin images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: |
             CACHEBURST_QIITACLIENT=${{ env.CACHEBURST_QIITACLIENT }}
             CACHEBURST_PLUGIN=${{ env.CACHEBURST_PLUGIN }}
-            GIT_PLUGIN_FORK=$GIT_PLUGIN_FORK
+            GIT_PLUGIN_FORK=${{ env.GIT_PLUGIN_FORK }}
             GIT_PLUGIN_BRANCH=${{ (env.GIT_PLUGIN_BRANCH == 'master' && matrix.plugin == 'qtp-job-output-folder') && 'main' || env.GIT_PLUGIN_BRANCH }}
-            GIT_QIITACLIENT_FORK=$GIT_QIITACLIENT_FORK
-            GIT_QIITACLIENT_BRANCH=$GIT_QIITACLIENT_BRANCH
+            GIT_QIITACLIENT_FORK=${{ env.GIT_QIITACLIENT_FORK }}
+            GIT_QIITACLIENT_BRANCH=${{ env.GIT_QIITACLIENT_BRANCH }}
           file: Images/${{ matrix.plugin }}/${{ matrix.plugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate
-          cache-from: type=gha,scope=tinqiita-plugin-${{ matrix.plugin }}-${{ github.ref_name }}
-          cache-to: type=gha,scope=tinqiita-plugin-${{ matrix.plugin }}-${{ github.ref_name }},mode=max
+          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
+          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
           platforms: linux/amd64
 
       - name: adapt compose file to select specific plugin
@@ -208,11 +208,11 @@ jobs:
           docker compose exec qiita-db psql -U postgres -d qiita_test -c "SELECT * FROM qiita.software;" || true
 
       - name: Execute tests in the running services
+        env:
+          GIT_PLUGIN_BRANCH: ${{ (env.GIT_PLUGIN_BRANCH == 'master' && matrix.plugin == 'qtp-job-output-folder') && 'main' || env.GIT_PLUGIN_BRANCH }}
         run: |
           sleep 10
-          fork=`if [[ "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" || "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "qiita-spots"; else echo "jlab"; fi`
-          branch=`if [[ "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" ]]; then echo "master"; elif [[ "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "main"; else echo "master"; fi`
-          docker compose exec ${{ matrix.plugin }} /bin/bash -c "PLUGIN_FORK=$fork PLUGIN_BRANCH=$branch bash /test_plugin.sh"
+          docker compose exec ${{ matrix.plugin }} /bin/bash -c "PLUGIN_FORK=${{ env.GIT_PLUGIN_FORK }} PLUGIN_BRANCH=${{ env.GIT_PLUGIN_BRANCH }} bash /test_plugin.sh"
 
       - name: Show Debug Logfiles
         #if: failure()
@@ -223,7 +223,7 @@ jobs:
 
       - name: Push image to ghcr (only if tests passed)
         if: success()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -253,12 +253,12 @@ jobs:
           cp Images/start_plugin.sh Images/test_plugin.sh Images/${{ matrix.multiplugin }}/requirements.txt Images/trigger.py .
 
       - name: Download certificates from job build_main
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: certificates
           path: ./
       - name: Download fake references
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: fake_references
           path: ./
@@ -271,13 +271,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build plugin images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Images/${{ matrix.multiplugin }}/${{ matrix.multiplugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate
-          cache-from: type=gha,scope=tinqiita-plugin-${{ matrix.multiplugin }}-${{ github.ref_name }}
-          cache-to: type=gha,scope=tinqiita-plugin-${{ matrix.multiplugin }}-${{ github.ref_name }},mode=max
+          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
+          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
           platforms: linux/amd64
 
       - name: Prune build cache after build (saving disc space)
@@ -304,7 +304,7 @@ jobs:
 
       - name: Push image to ghcr (only if tests passed)
         if: success()
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -76,10 +76,11 @@ jobs:
           push: true
           file: Images/${{ matrix.container }}/${{ matrix.container }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:testcandidate
-          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
-          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
+        #  cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
+          cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}-main
+        #  cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
+          cache-to: type=gha,scope=tinqiita-${{ github.ref_name }}-main,mode=max
           platforms: linux/amd64
-
   make_references:
     needs: build_main
     runs-on: ubuntu-latest
@@ -163,6 +164,8 @@ jobs:
           compose-file: "compose.yaml"
           services: |
             nginx
+      - name: Check which qiita image is actually running
+        run: docker inspect ghcr.io/${{ github.repository }}/qiita:testcandidate --format '{{.Id}}'
       - name: Show docker compose logs
         if: failure()
         run: |

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -172,8 +172,8 @@ jobs:
       - name: Execute tests in the running services
         run: |
           sleep 10
-          fork=`if [[ "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" || "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "jlab"; else echo "qiita-spots"; fi`
-          branch=`if [[ "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" || "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "uncouple_clientpush"; else echo "master"; fi`
+          fork=`if [[ "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" || "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "qiita-spots"; else echo "jlab"; fi`
+          branch=`if [[ "${{ matrix.plugin }}" == "qp-target-gene" || "${{ matrix.plugin }}" == "qp-deblur" || "${{ matrix.plugin }}" == "qtp-sequencing" || "${{ matrix.plugin }}" == "qtp-biom" || "${{ matrix.plugin }}" == "qtp-visualization" || "${{ matrix.plugin }}" == "qtp-diversity" ]]; then echo "master"; elif [[ "${{ matrix.plugin }}" == "qtp-job-output-folder" ]]; then echo "main"; else echo "master"; fi`
           docker compose exec ${{ matrix.plugin }} /bin/bash -c "PLUGIN_FORK=$fork PLUGIN_BRANCH=$branch bash /test_plugin.sh"
 
       - name: Show Debug Logfiles

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -204,7 +204,7 @@ jobs:
           docker compose ps
           docker compose logs
 
-      - name: debug
+      - name: Inspect plugin container and qiita DB for debugging
         run: |
           docker compose exec ${{ matrix.plugin }} /bin/bash -c "ls -la /; ls -la /unshared_plugins/; cat /unshared_plugins/*;" || true
           docker compose exec qiita-db psql -U postgres -d qiita_test -c "SELECT * FROM qiita.software;" || true
@@ -217,7 +217,7 @@ jobs:
           docker compose exec ${{ matrix.plugin }} /bin/bash -c "PLUGIN_FORK=${{ env.GIT_PLUGIN_FORK }} PLUGIN_BRANCH=${{ env.GIT_PLUGIN_BRANCH }} bash /test_plugin.sh"
 
       - name: Show Debug Logfiles
-        #if: failure()
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: debug logs
@@ -290,7 +290,7 @@ jobs:
           bash .github/workflows/adapt_compose.yaml.sh ./compose.yaml "${{ matrix.multiplugin }}"
 
       - name: Run docker compose
-        uses: hoverkraft-tech/compose-action@v2.0.1
+        uses: hoverkraft-tech/compose-action@v2.6.0
         with:
           compose-file: "compose.yaml"
           services: |

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -181,6 +181,8 @@ jobs:
           cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
           cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
           platforms: linux/amd64
+          load: true
+          push: false
 
       - name: adapt compose file to select specific plugin
         run: |
@@ -223,12 +225,7 @@ jobs:
 
       - name: Push image to ghcr (only if tests passed)
         if: success()
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          file: Images/${{ matrix.plugin }}/${{ matrix.plugin }}.dockerfile
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate
+        run: docker push ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate
 
   # the qp-qiime2 plugin cannot be tested in isolation, it also needs qtp-diversity and qtp-visualization to be active in qiita
   build_mulit_plugins:
@@ -279,6 +276,8 @@ jobs:
           cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
           cache-to: type=gha,scope=tinqiita-${{ github.ref_name }},mode=max
           platforms: linux/amd64
+          load: true
+          push: false
 
       - name: Prune build cache after build (saving disc space)
         run: |
@@ -304,12 +303,7 @@ jobs:
 
       - name: Push image to ghcr (only if tests passed)
         if: success()
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          file: Images/${{ matrix.multiplugin }}/${{ matrix.multiplugin }}.dockerfile
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate
+        run: docker push ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate
 
   publish_images:
     needs:

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -83,8 +83,8 @@ jobs:
           push: true
           build-args: |
             CACHEBURST_QIITA=${{ env.CACHEBURST_QIITA }}
-            GIT_QIITA_FORK=$GIT_QIITA_FORK
-            GIT_QIITA_BRANCH=$GIT_QIITA_BRANCH
+            GIT_QIITA_FORK=${{ env.GIT_QIITA_FORK }}
+            GIT_QIITA_BRANCH=${{ env.GIT_QIITA_BRANCH }}
           file: Images/${{ matrix.container }}/${{ matrix.container }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:testcandidate
           cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -235,6 +235,11 @@ jobs:
       matrix:
         multiplugin: ["qp-qiime2"]
     runs-on: ubuntu-latest
+    env:
+      GIT_PLUGIN_FORK: "qiita-spots"
+      GIT_PLUGIN_BRANCH: "master"
+      GIT_QIITACLIENT_FORK: "qiita-spots"
+      GIT_QIITACLIENT_BRANCH: "master"
     steps:
       - name: Checkout tinqiita repo
         uses: actions/checkout@v6
@@ -267,10 +272,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get commit-hash of qiita_client and plugin
+        run: |
+          echo "CACHEBURST_PLUGIN=$(git ls-remote https://github.com/$GIT_PLUGIN_FORK/${{ matrix.multiplugin }}.git refs/heads/$GIT_PLUGIN_BRANCH | cut -f1)" >> $GITHUB_ENV
+          echo "CACHEBURST_QIITACLIENT=$(git ls-remote https://github.com/$GIT_QIITACLIENT_FORK/qiita_client.git refs/heads/$GIT_QIITACLIENT_BRANCH | cut -f1)" >> $GITHUB_ENV
+
       - name: Build plugin images
         uses: docker/build-push-action@v7
         with:
           context: .
+          build-args: |
+            CACHEBURST_QIITACLIENT=${{ env.CACHEBURST_QIITACLIENT }}
+            CACHEBURST_PLUGIN=${{ env.CACHEBURST_PLUGIN }}
+            GIT_PLUGIN_FORK=${{ env.GIT_PLUGIN_FORK }}
+            GIT_PLUGIN_BRANCH=${{  env.GIT_PLUGIN_BRANCH }}
+            GIT_QIITACLIENT_FORK=${{ env.GIT_QIITACLIENT_FORK }}
+            GIT_QIITACLIENT_BRANCH=${{ env.GIT_QIITACLIENT_BRANCH }}
           file: Images/${{ matrix.multiplugin }}/${{ matrix.multiplugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate
           cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
@@ -295,6 +312,16 @@ jobs:
           compose-file: "compose.yaml"
           services: |
             nginx
+
+      - name: Check which qiita and plugin image is actually running
+        run: |
+          docker inspect ghcr.io/${{ github.repository }}/qiita:testcandidate --format '{{.Id}}'
+          docker inspect ghcr.io/${{ github.repository }}/${{ matrix.multiplugin }}:testcandidate --format '{{.Id}}'
+      - name: Show docker compose logs
+        if: failure()
+        run: |
+          docker compose ps
+          docker compose logs
 
       - name: Execute tests in the running services
         run: |

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -172,6 +172,13 @@ jobs:
           docker compose ps
           docker compose logs
 
+      - name: debug
+        run: |
+          ls -la /
+          ls -la /unshared_plugins/
+          cat /unshared_plugins/*
+          docker compose exec qiita-db psql -U postgres -d qiita_test -c "SELECT * FROM qiita.software;"
+
       - name: Execute tests in the running services
         run: |
           sleep 10

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -174,10 +174,8 @@ jobs:
 
       - name: debug
         run: |
-          ls -la /
-          ls -la /unshared_plugins/
-          cat /unshared_plugins/*
-          docker compose exec qiita-db psql -U postgres -d qiita_test -c "SELECT * FROM qiita.software;"
+          docker compose exec ${{ matrix.plugin }} /bin/bash -c "ls -la /; ls -la /unshared_plugins/; cat /unshared_plugins/*;" || true
+          docker compose exec qiita-db psql -U postgres -d qiita_test -c "SELECT * FROM qiita.software;" || true
 
       - name: Execute tests in the running services
         run: |

--- a/.github/workflows/buildContainer.yaml
+++ b/.github/workflows/buildContainer.yaml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         container: ["nginx", "qiita", "plugin_collector"]
     runs-on: ubuntu-latest
+    env:
+      GIT_QIITA_FORK: "jlab"
+      GIT_QIITA_BRANCH: "auth_oidc"
     steps:
       - name: Checkout tinqiita repo
         uses: actions/checkout@v4
@@ -69,11 +72,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get commit-hash of qiita
+        run: |
+          echo "CACHEBURST_QIITA=$(git ls-remote https://github.com/$GIT_QIITA_FORK/qiita.git refs/heads/$GIT_QIITA_BRANCH | cut -f1)" >> $GITHUB_ENV
+
       - name: Build main qiita images and push to github's own registry
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          build-args: |
+            CACHEBURST_QIITA=${{ env.CACHEBURST_QIITA }}
+            GIT_QIITA_FORK=$GIT_QIITA_FORK
+            GIT_QIITA_BRANCH=$GIT_QIITA_BRANCH
           file: Images/${{ matrix.container }}/${{ matrix.container }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.container }}:testcandidate
           cache-from: type=gha,scope=tinqiita-${{ github.ref_name }}
@@ -109,6 +120,11 @@ jobs:
       matrix:
         plugin: ["qp-deblur", "qtp-biom", "qtp-sequencing", "qtp-visualization", "qtp-diversity", "qp-target-gene", "qtp-job-output-folder"]
     runs-on: ubuntu-latest
+    env:
+      GIT_PLUGIN_FORK: "qiita-spots"
+      GIT_PLUGIN_BRANCH: "master"
+      GIT_QIITACLIENT_FORK: "qiita-spots"
+      GIT_QIITACLIENT_BRANCH: "master"
     steps:
       - name: Checkout tinqiita repo
         uses: actions/checkout@v4
@@ -142,10 +158,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get commit-hash of qiita_client and plugin
+        env:
+          GIT_PLUGIN_BRANCH: ${{ (env.GIT_PLUGIN_BRANCH == 'master' && matrix.plugin == 'qtp-job-output-folder') && 'main' || env.GIT_PLUGIN_BRANCH }}
+        run: |
+          echo "CACHEBURST_PLUGIN=$(git ls-remote https://github.com/$GIT_PLUGIN_FORK/${{ matrix.plugin }}.git refs/heads/$GIT_PLUGIN_BRANCH | cut -f1)" >> $GITHUB_ENV
+          echo "CACHEBURST_QIITACLIENT=$(git ls-remote https://github.com/$GIT_QIITACLIENT_FORK/qiita_client.git refs/heads/$GIT_QIITACLIENT_BRANCH | cut -f1)" >> $GITHUB_ENV
+
       - name: Build plugin images
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: |
+            CACHEBURST_QIITACLIENT=${{ env.CACHEBURST_QIITACLIENT }}
+            CACHEBURST_PLUGIN=${{ env.CACHEBURST_PLUGIN }}
+            GIT_PLUGIN_FORK=$GIT_PLUGIN_FORK
+            GIT_PLUGIN_BRANCH=${{ (env.GIT_PLUGIN_BRANCH == 'master' && matrix.plugin == 'qtp-job-output-folder') && 'main' || env.GIT_PLUGIN_BRANCH }}
+            GIT_QIITACLIENT_FORK=$GIT_QIITACLIENT_FORK
+            GIT_QIITACLIENT_BRANCH=$GIT_QIITACLIENT_BRANCH
           file: Images/${{ matrix.plugin }}/${{ matrix.plugin }}.dockerfile
           tags: ghcr.io/${{ github.repository }}/${{ matrix.plugin }}:testcandidate
           cache-from: type=gha,scope=tinqiita-plugin-${{ matrix.plugin }}-${{ github.ref_name }}

--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -52,6 +52,8 @@ RUN pip install \
 # Clone the Qiita Repo: currently we need the oidc changes from our jlab fork + changes in the tornado_FetchFileFromCentralHandler branch, which send files if requested directly from tornado instead of nginx (happens in testing)
 # RUN git clone -b master https://github.com/qiita-spots/qiita.git
 ARG CACHEBURST_QIITA=1
+ENV GIT_QIITA_BRANCH=${GIT_QIITA_BRANCH}
+ENV GIT_QIITA_FORK=${GIT_QIITA_FORK}
 RUN git clone -b ${GIT_QIITA_BRANCH} https://github.com/${GIT_QIITA_FORK}/qiita.git \
 	&& cd qiita \
 	&& git config pull.rebase false \

--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -5,6 +5,8 @@ FROM ubuntu:24.04
 ARG MINIFORGE_VERSION=24.1.2-0
 ARG MODZIP_VERSION=1.3.0
 ARG NGINX_VERSION=1.26.0
+ARG GIT_QIITA_BRANCH=auth_oidc
+ARG GIT_QIITA_FORK=jlab
 
 ENV CONDA_DIR=/opt/conda
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -49,7 +51,8 @@ RUN pip install \
 
 # Clone the Qiita Repo: currently we need the oidc changes from our jlab fork + changes in the tornado_FetchFileFromCentralHandler branch, which send files if requested directly from tornado instead of nginx (happens in testing)
 # RUN git clone -b master https://github.com/qiita-spots/qiita.git
-RUN git clone -b auth_oidc https://github.com/jlab/qiita.git \
+ARG CACHEBURST_QIITA=1
+RUN git clone -b ${GIT_QIITA_BRANCH} https://github.com/${GIT_QIITA_FORK}/qiita.git \
 	&& cd qiita \
 	&& git config pull.rebase false \
 	&& git config --global user.email "jlab@uni-giessen.de" \

--- a/Images/qiita/qiita.dockerfile
+++ b/Images/qiita/qiita.dockerfile
@@ -60,9 +60,6 @@ RUN sed -i "s|'source /home/runner/.profile; conda activate qiita'|'source /opt/
 RUN sed -i "s|'source ~/virtualenv/python2.7/bin/activate; export PATH=\$HOME/miniconda3/bin/:\$PATH; . activate qtp-biom'|'true'|" /qiita/qiita_db/support_files/populate_test_db.sql
 RUN sed -i "s|'source activate qiita'|'true'|" /qiita/qiita_db/support_files/populate_test_db.sql
 
-# there seems to be a conflict with parameter names für qp-target-gene. See: https://github.com/qiita-spots/qp-target-gene/issues/24
-RUN sed -i "s|'1.9.1',|'1.9.hide',|" /qiita/qiita_db/support_files/populate_test_db.sql
-
 # We need to install necessary dependencies
 # as well as some extra dependencies for psycopg2 to work
 RUN git clone https://github.com/psycopg/psycopg2.git

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qp-deblur
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -55,7 +59,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 
 # Install qiita_client
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
-RUN git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+ARG CACHEBURST_QIITACLIENT=1
+RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -66,7 +71,9 @@ RUN conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.3
 	pip install -U pip pip-system-certs
 
 # Install qiita plugin
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN pip install .
 

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -23,6 +23,10 @@ ARG PLUGIN
 ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 # config for conda within plugin image
 ARG MINIFORGE_VERSION=24.1.2-0
@@ -60,6 +64,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # Install qiita_client
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
@@ -72,6 +78,8 @@ RUN conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.3
 
 # Install qiita plugin
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qp-deblur/qp-deblur.dockerfile
+++ b/Images/qp-deblur/qp-deblur.dockerfile
@@ -66,7 +66,7 @@ RUN conda install --quiet --yes -c bioconda -c biocore "VSEARCH=2.7.0" MAFFT=7.3
 	pip install -U pip pip-system-certs
 
 # Install qiita plugin
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN pip install .
 

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -89,7 +89,7 @@ RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip \
 
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qp-qiime2.git
-RUN git clone --depth 1 -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone --depth 1 -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN sed -i "s|self.basedir, '..', '..', '|'/|g" /${PLUGIN}/qp_qiime2/tests/test_qiime2.py && \
     sed -i "s|'gneiss', ||" /${PLUGIN}/qp_qiime2/qp_qiime2.py && \

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -23,6 +23,10 @@ ARG PLUGIN
 ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 # let the container know it's plugin name
 ENV PLUGIN=${PLUGIN}
@@ -82,6 +86,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # Install qiita_client
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN pip install -U pip && \
 	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
@@ -95,6 +101,8 @@ RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip \
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qp-qiime2.git
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone --depth 1 -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qp-qiime2/qp-qiime2.dockerfile
+++ b/Images/qp-qiime2/qp-qiime2.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qp-qiime2
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -77,8 +81,9 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 
 # Install qiita_client
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
+ARG CACHEBURST_QIITACLIENT=1
 RUN pip install -U pip && \
-	git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -89,7 +94,9 @@ RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip \
 
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qp-qiime2.git
-RUN git clone --depth 1 -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone --depth 1 -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN sed -i "s|self.basedir, '..', '..', '|'/|g" /${PLUGIN}/qp_qiime2/tests/test_qiime2.py && \
     sed -i "s|'gneiss', ||" /${PLUGIN}/qp_qiime2/qp_qiime2.py && \

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qp-target-gene
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -60,7 +64,8 @@ RUN pip install -U pip
 # Install qiita_client
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 #RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
-RUN git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+ARG CACHEBURST_QIITACLIENT=1
+RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -68,8 +73,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita_client.git && \
 RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip
 
 # Install qiita plugin
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN} \
-	&& git -C /${PLUGIN} rev-parse HEAD
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN pip install biom-format && \
 	pip install -e . && \

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -72,6 +72,7 @@ ARG CACHEBURST_QIITACLIENT=1
 ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
 ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
+	git -C qiita_client rev-parse HEAD && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -68,7 +68,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita_client.git && \
 RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip
 
 # Install qiita plugin
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN} \
+	&& git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN pip install biom-format && \
 	pip install -e . && \

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -23,6 +23,10 @@ ARG PLUGIN
 ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -65,6 +69,8 @@ RUN pip install -U pip
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 #RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
@@ -74,6 +80,9 @@ RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip
 
 # Install qiita plugin
 ARG CACHEBURST_PLUGIN=1
+ENV PLUGIN=${PLUGIN}
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qp-target-gene/qp-target-gene.dockerfile
+++ b/Images/qp-target-gene/qp-target-gene.dockerfile
@@ -68,7 +68,7 @@ RUN git clone -b master https://github.com/qiita-spots/qiita_client.git && \
 RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip
 
 # Install qiita plugin
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN pip install biom-format && \
 	pip install -e . && \

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -24,6 +24,10 @@ ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
 ARG QIIME2RELEASE=2022.8
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -76,6 +80,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN pip install -U pip && \
 	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
@@ -89,6 +95,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qtp-biom
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -71,8 +75,9 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
+ARG CACHEBURST_QIITACLIENT=1
 RUN pip install -U pip && \
-	git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -83,7 +88,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/qiita-spots/'||" setup.py && \
 	sed -i "s|'qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-biom/qtp-biom.dockerfile
+++ b/Images/qtp-biom/qtp-biom.dockerfile
@@ -83,7 +83,7 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/qiita-spots/'||" setup.py && \
 	sed -i "s|'qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -81,7 +81,7 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 #RUN pip install https://github.com/biocore/q2-mislabeled/archive/refs/heads/main.zip
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/'||" setup.py && \
 	sed -i "s|'qiita-spots/qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -24,6 +24,10 @@ ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
 ARG QIIME2RELEASE=2022.11
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -73,6 +77,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN pip install -U pip && \
 	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
@@ -87,6 +93,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 # Install qiita plugin
 #RUN pip install https://github.com/biocore/q2-mislabeled/archive/refs/heads/main.zip
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qtp-diversity/qtp-diversity.dockerfile
+++ b/Images/qtp-diversity/qtp-diversity.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qtp-diversity
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -68,8 +72,9 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
+ARG CACHEBURST_QIITACLIENT=1
 RUN pip install -U pip && \
-	git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -81,7 +86,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 #RUN pip install https://github.com/biocore/q2-mislabeled/archive/refs/heads/main.zip
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/'||" setup.py && \
 	sed -i "s|'qiita-spots/qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -66,7 +66,7 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b  uncouple_clientpush   https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b main https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /qtp-job-output-folder
 RUN sed -i 's|"qiita-files @ https://github.com/qiita-spots/qiita-files/archive/master.zip",||' setup.py && \
 	sed -i 's|"qiita_client @ https://github.com/qiita-spots/qiita_client/archive/master.zip",||' setup.py && \

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -23,6 +23,10 @@ ARG PLUGIN
 ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -61,6 +65,8 @@ RUN pip install -U pip
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 #RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
@@ -73,6 +79,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /qtp-job-output-folder

--- a/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
+++ b/Images/qtp-job-output-folder/qtp-job-output-folder.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qtp-job-output-folder
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=main
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -56,8 +60,10 @@ RUN pip install -U pip
 
 #RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 #RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
-RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
-RUN cd qiita_client && pip install --no-cache-dir .
+ARG CACHEBURST_QIITACLIENT=1
+RUN git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
+	cd qiita_client && \
+	pip install --no-cache-dir .
 
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita-files/archive/master.zip
@@ -66,7 +72,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b main https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /qtp-job-output-folder
 RUN sed -i 's|"qiita-files @ https://github.com/qiita-spots/qiita-files/archive/master.zip",||' setup.py && \
 	sed -i 's|"qiita_client @ https://github.com/qiita-spots/qiita_client/archive/master.zip",||' setup.py && \

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qtp-sequencing
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -52,8 +56,9 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
+ARG CACHEBURST_QIITACLIENT=1
 RUN pip install -U pip && \
-	git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -65,7 +70,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qtp-sequencing.git
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/'||" setup.py && \
 	sed -i "s|'qiita-spots/qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -23,6 +23,10 @@ ARG PLUGIN
 ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -57,6 +61,8 @@ SHELL ["conda", "run", "-p", "${CONDA_DIR}/envs/${PLUGIN}", "/bin/bash", "-c"]
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN pip install -U pip && \
 	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
@@ -71,6 +77,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qtp-sequencing.git
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}

--- a/Images/qtp-sequencing/qtp-sequencing.dockerfile
+++ b/Images/qtp-sequencing/qtp-sequencing.dockerfile
@@ -65,7 +65,7 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 #RUN git clone https://github.com/qiita-spots/qtp-sequencing.git
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'qiita-files @ https://github.com/'||" setup.py && \
 	sed -i "s|'qiita-spots/qiita-files/archive/master.zip',||" setup.py && \

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -81,9 +81,11 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b uncouple_clientpush  https://github.com/jlab/${PLUGIN}.git /${PLUGIN}
+RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
 WORKDIR /${PLUGIN}
-RUN sed -i "s|'qiita_client', 'click >= 3.3', 'qiime2'|'click >= 3.3'|" setup.py && \
+RUN sed -i "s|'click >= 3.3', 'qiime2'|'click >= 3.3'|" setup.py && \
+	sed -i "s|'qiita_client @ https://github.com/'||" setup.py && \
+	sed -i "s|'qiita-spots/qiita_client/archive/master.zip'||" setup.py && \
 	pip install -e . && \
 	pip install --upgrade certifi && \
 	pip install pip-system-certs

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -3,6 +3,10 @@
 # variables, specifically for this plugin
 # qiita plugin name
 ARG PLUGIN=qtp-visualization
+ARG GIT_PLUGIN_BRANCH=master
+ARG GIT_PLUGIN_FORK=qiita-spots
+ARG GIT_QIITACLIENT_BRANCH=master
+ARG GIT_QIITACLIENT_FORK=qiita-spots
 
 # variables, identical for whole qiita setup
 ARG QIITA_PLUGINS_DIR=/unshared_plugins
@@ -69,8 +73,9 @@ ENV LANG=C.UTF-8
 # Install qiita_client
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
+ARG CACHEBURST_QIITACLIENT=1
 RUN pip install -U pip && \
-	git clone -b master https://github.com/qiita-spots/qiita_client.git && \
+	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
 	pip install --no-cache-dir .
 
@@ -81,7 +86,9 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 	pip install -e . -v
 
 # Install qiita plugin
-RUN git clone -b master https://github.com/qiita-spots/${PLUGIN}.git /${PLUGIN}
+ARG CACHEBURST_PLUGIN=1
+RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
+	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}
 RUN sed -i "s|'click >= 3.3', 'qiime2'|'click >= 3.3'|" setup.py && \
 	sed -i "s|'qiita_client @ https://github.com/'||" setup.py && \

--- a/Images/qtp-visualization/qtp-visualization.dockerfile
+++ b/Images/qtp-visualization/qtp-visualization.dockerfile
@@ -24,6 +24,10 @@ ARG QIITA_PLUGINS_DIR
 ARG QIITA_CERT_DIR
 ARG CONDA_DIR
 ARG QIIME2RELEASE=2023.5
+ARG GIT_PLUGIN_BRANCH
+ARG GIT_PLUGIN_FORK
+ARG GIT_QIITACLIENT_BRANCH
+ARG GIT_QIITACLIENT_FORK
 
 ARG MINIFORGE_VERSION=24.1.2-0
 ENV PATH=${CONDA_DIR}/bin:${PATH}
@@ -74,6 +78,8 @@ ENV LANG=C.UTF-8
 # RUN pip install https://github.com/qiita-spots/qiita_client/archive/master.zip
 # RUN git clone -b master https://github.com/qiita-spots/qiita_client.git
 ARG CACHEBURST_QIITACLIENT=1
+ENV GIT_QIITACLIENT_BRANCH=${GIT_QIITACLIENT_BRANCH}
+ENV GIT_QIITACLIENT_FORK=${GIT_QIITACLIENT_FORK}
 RUN pip install -U pip && \
 	git clone -b ${GIT_QIITACLIENT_BRANCH} https://github.com/${GIT_QIITACLIENT_FORK}/qiita_client.git && \
 	cd qiita_client && \
@@ -87,6 +93,8 @@ RUN git clone -b master https://github.com/qiita-spots/qiita-files.git && \
 
 # Install qiita plugin
 ARG CACHEBURST_PLUGIN=1
+ENV GIT_PLUGIN_BRANCH=${GIT_PLUGIN_BRANCH}
+ENV GIT_PLUGIN_FORK=${GIT_PLUGIN_FORK}
 RUN git clone -b ${GIT_PLUGIN_BRANCH} https://github.com/${GIT_PLUGIN_FORK}/${PLUGIN}.git /${PLUGIN} && \
 	git -C /${PLUGIN} rev-parse HEAD
 WORKDIR /${PLUGIN}


### PR DESCRIPTION
After Antonio and I merged necessary updates to uncouple file system between plugins and qiita, this PR switches from uncouple_clientpush@jlab branches back to master/main@qiita-spots branches for q(t)p-plugins